### PR TITLE
WIP: Registrations, DO NOT MERGE, demo only

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -152,6 +152,7 @@ NAVIGATION_LINKS = {
         ("/volunteer/", "Volunteer"),
         ("/fa/", "Financial Aid"),
         ("/code-of-conduct/", "Code of Conduct"),
+        ("/registration", "Registration"),
         # ("/archive.html", "Archive"),
         # ("/categories/", "Tags"),
         # ("/rss.xml", "RSS feed"),
@@ -170,6 +171,7 @@ NAVIGATION_LINKS = {
         # ("https://mailchi.mp/a7731abffa7b/pycon-canada-2018-volunteers", "Lieu"),
         # ("#", "Aide financière"),
         ("/fr/code-of-conduct/", "Code de conduite"),
+        ("/fr/registration/", "Enregistrement")
         # ("/fr/archive.html", "Archives"),
         # ("/fr/categories/", "Étiquettes"),
         # ("/fr/rss.xml", "Flux RSS"),

--- a/pages/registration.en.rst
+++ b/pages/registration.en.rst
@@ -1,0 +1,54 @@
+.. title: PyCon Canada 2018 Registration Information
+.. slug: registration
+.. date: 2018-09-19 21:23:22 UTC+04:00
+.. type: text
+
+
+There are three different kind of tickets.
+Pycon Canada 2017 registration gives access to sessions from November 10-11th with sprints being free.
+
+    * Student ($88 + Taxes & Fees)
+    * Super Early Bird ($100 CAD + Taxes & Fees)
+    * Early Bird ($125 CAD + Taxes & Fees)
+    * Individual ($150 + Taxes & Fees)
+    * Corporate ($250 + Taxes & Fees)
+    * Contributor ($600 + Taxes & Fees)
+    * Donation
+
+
+Super Early Bird
+================
+
+We offer special discounted ticket for those who really love PyCon so never care about the event details. Limited quantity available.
+
+Early Bird
+==========
+
+Discounted tickets for 2018 Pycon Canada. Limited quantity available.
+
+
+Individual
+==========
+
+You missed early bird ticket or the tickets were sold out too quickly? Don't worry, You can still buy a regular ticket. When early bird tickets are sold out or early bird sales end you can buy a regular ticket for PyCon Canada 2018.
+
+A patron ticket price start from $150 CAD + Taxes & Fees, but you can donate as many you want! An individual ticket include 1 regular ticket regardless how much you donate. Also, please keep in mind that a is not transferable or refundable.
+
+
+Corporate & Contributor
+=======================
+
+All conference attendees including event chair, volunteers, speakers pays for PyCon registration. This is beloved philosophy of PyCon. That way, we can achieve the attendees be part of the conference with equal status. `Everybody Pays <http://jessenoller.com/blog/2011/05/25/pycon-everybody-pays>`_
+
+However, this philosophy might be a barrier to someone who can not afford for the ticket or expense of traveling. To mitigate this, PyCon Canada provides financial aid to help people attend PyCon.
+
+Financial aid recipients have some part of their expenses, which may include registration, travel or accomodation, paid from PyCon budget. While we can't cover all expenses for everyone, we try our hardest to optimally allocate our budget. All Contributor and Corporate tickets sales would go to financial aid fund.
+
+
+
+
+.. raw:: html
+
+    <div class="btn-group">
+        <a class="btn btn-outline-red btn-lg" href="https://pyconca2018.eventbrite.com" role="button">Buy a ticket to PyConCA 2018</a>
+    </div>

--- a/pages/registration.fr.rst
+++ b/pages/registration.fr.rst
@@ -1,0 +1,11 @@
+.. title: PyCon Canada 2018 Registration Information
+.. slug: registration
+.. date: 2018-09-19 21:23:22 UTC+04:00
+.. type: text
+
+
+.. raw:: html
+
+    <div class="btn-group">
+        <a class="btn btn-outline-red btn-lg" href="https://pyconca2018.eventbrite.com" role="button">Acheter un Billet aux PyConCA 2018</a>
+    </div>

--- a/themes/pycon-ca-2018/templates/base.tmpl
+++ b/themes/pycon-ca-2018/templates/base.tmpl
@@ -65,9 +65,6 @@
                             </a>
                         </li>
                     {% endif %}
-                    <li class="nav-item ml-lg-4">
-                      <a class="btn btn-round btn-dark-cyan" href="https://pyconca2018.eventbrite.com">Buy a Ticket</a>
-                    </li>
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
Initial draft of registration page, explaining ticket pricing, almost completely lifted from -- https://www.pycon.kr/2017/en/registration/information/ 

The diff also removes Buy A ticket button from the page header everywhere

- [ ] Proofread
- [ ] Clarify Contributor & Corporate sections
- [ ] Cleanup/clarify/combine Regular, Contributor & Corporate sections
- [ ] Get a french translations.