### PR TITLE
Change Talk Title

### DIFF
--- a/data/talks/PC-55560.yaml
+++ b/data/talks/PC-55560.yaml
@@ -4,7 +4,7 @@
 
 speaker_name: "Erik Wright"
 
-talk_title: "Agile Testing!"
+talk_title: "Nimble Testing!"
 
 # At least 1 tag is necessary!!
 talk_tags:


### PR DESCRIPTION
It turns out that Agile is a capital-A thing very different from "agile" the adjective that I intended. So let's not add too much baggage in the title of this talk.